### PR TITLE
Update colors.xml

### DIFF
--- a/colors.xml
+++ b/colors.xml
@@ -35,7 +35,7 @@
          <gameArtCornerRadius>0.02</gameArtCornerRadius>
          <helpsystemFont>default</helpsystemFont>
          <helpsystemLetterCase>uppercase</helpsystemLetterCase>
-         <helpsystemIconColor>454e45</helpsystemIconColor>
+         <helpsystemIconColor>F7FBF7</helpsystemIconColor>
          <helpsystemTextColor>F7FBF7</helpsystemTextColor>
          <badgeIconColor>454e45</badgeIconColor>
       </variables>


### PR DESCRIPTION
While the icons are more than readable on my -high end- computer screen they are a bit harsh to see in lower resolutions and handhelds.
As you can see on my Anbernic RG Cube, with a resolution of 720p:
![image](https://github.com/user-attachments/assets/84abe548-5ff4-4a85-860e-b6bd5f285ff1)

The original theme also uses white colors in the bottom, even tho it uses some lighter background as well.
![image](https://github.com/user-attachments/assets/0ab1fdd0-15f3-4be7-ba65-fb1560866c8e)
